### PR TITLE
Add missing surefire plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,6 +190,11 @@
           <artifactId>maven-project-info-reports-plugin</artifactId>
           <version>3.0.0</version>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.22.2</version>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>


### PR DESCRIPTION
Add surefire plugin back to default profile in `pom.xml` - without this, unit tests won't run with `mvn test`